### PR TITLE
feat: add multiple queue configurations support. Closes #1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -102,7 +102,7 @@ dotnet_naming_symbols.static_fields.applicable_kinds = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
 dotnet_naming_style.static_field_style.capitalization = camel_case
-dotnet_naming_style.static_field_style.required_prefix = s_
+dotnet_naming_style.static_field_style.required_prefix = _
 
 # Instance fields are camelCase and start with _
 dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/__tests__/BlogDoFt.QueueComponentTest/bin/Debug/netcoreapp3.1/BlogDoFt.QueueComponentTest.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/__tests__/BlogDoFt.QueueComponentTest",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.ignoreWords": [
+        "editorconfig",
         "sonarscanner",
         "wireframes"
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/__tests__/BlogDoFt.QueueComponentTest/BlogDoFt.QueueComponentTest.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/__tests__/BlogDoFt.QueueComponentTest/BlogDoFt.QueueComponentTest.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/__tests__/BlogDoFt.QueueComponentTest/BlogDoFt.QueueComponentTest.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/__tests__/BlogDoFt.QueueComponentTest/BlogDoFt.QueueComponentTest.csproj
+++ b/__tests__/BlogDoFt.QueueComponentTest/BlogDoFt.QueueComponentTest.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <CodeAnalysisRuleSet>..\..\.ruleset</CodeAnalysisRuleSet>
+    <ProjectGuid>FD2BBDBC-C01C-451C-9653-11F5947C6747</ProjectGuid>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="31.0.3" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -31,13 +34,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlogDoFt.QueueComponent\BlogDoFt.QueueComponent.csproj" />
   </ItemGroup>
-
 </Project>

--- a/__tests__/BlogDoFt.QueueComponentTest/Configurations/ConfigConnectionProviderTest.cs
+++ b/__tests__/BlogDoFt.QueueComponentTest/Configurations/ConfigConnectionProviderTest.cs
@@ -1,0 +1,56 @@
+﻿using BlogDoFt.QueueComponent.Configurations;
+using BlogDoFt.QueueComponent.Enums;
+using BlogDoFt.QueueComponentTest.Fixtures;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace BlogDoFt.QueueComponentTest.Configurations
+{
+    public class ConfigConnectionProviderTest
+    {
+        [Fact]
+        public void ShouldBeSingleton()
+        {
+            // Given
+            var oldInstance = ConfigConnectionProvider.NewInstance();
+
+            // When
+            var newInstance = ConfigConnectionProvider.NewInstance();
+
+            // Then
+            newInstance.Should().Be(oldInstance);
+        }
+
+        [Fact]
+        public void ShouldStorageAConfig()
+        {
+            // Given
+            var config = new QueueConnConfiguration();
+            var provider = ConfigConnectionProvider.NewInstance();
+
+            // When
+            Action act = () => provider.SetConfigTo<QueueStub>(config);
+
+            // Then
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void ShouldUpdateWhenTryStorageSameConfig()
+        {
+            // Given
+            var config = new QueueConnConfiguration { QueueMechanism = QueueMechanism.Kafka };
+            var updateConfig = new QueueConnConfiguration { QueueMechanism = QueueMechanism.RabbitMq };
+            var provider = ConfigConnectionProvider.NewInstance();
+            provider.SetConfigTo<QueueStub>(config);
+
+            // When
+            provider.SetConfigTo<QueueStub>(updateConfig);
+            var storedConfig = provider.GetConfigTo<QueueStub>();
+
+            // Then
+            storedConfig.Should().Be(updateConfig);
+        }
+    }
+}

--- a/__tests__/BlogDoFt.QueueComponentTest/Extensions/ConfigurationExtensionTest.cs
+++ b/__tests__/BlogDoFt.QueueComponentTest/Extensions/ConfigurationExtensionTest.cs
@@ -1,0 +1,74 @@
+﻿using BlogDoFt.QueueComponent.Configurations;
+using BlogDoFt.QueueComponent.Enums;
+using BlogDoFt.QueueComponent.Extensions;
+using BlogDoFt.QueueComponentTest.Fixtures;
+using Bogus;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace BlogDoFt.QueueComponentTest.Extensions
+{
+    public class ConfigurationExtensionTest
+    {
+        private readonly ServiceCollection _services;
+        private readonly Faker _faker;
+
+        public ConfigurationExtensionTest()
+        {
+            _services = new ServiceCollection();
+            _faker = FakerFixture.GetFaker();
+        }
+
+        [Fact]
+        public void ShouldAddAConnectionToSomeClass()
+        {
+            _services.AddQueueSupport();
+            var expectedQueueName = _faker.Lorem.Word();
+
+            _services.RegisterConnectionTo<QueueStub>((config) =>
+                config.QueueName = expectedQueueName);
+
+            using var provider = _services.BuildServiceProvider();
+            var prov = provider.GetRequiredService<ConfigConnectionProvider>();
+            prov.Should().NotBeNull();
+            prov.GetConfigTo<QueueStub>().QueueName.Should().Be(expectedQueueName);
+        }
+
+        [Fact]
+        public void ShouldReAddAConnectionOnlyChangingFields()
+        {
+            _services.AddQueueSupport();
+            var expectedQueueName = _faker.Lorem.Word();
+            const QueueMechanism ExpectedQueueMechanism = QueueMechanism.Kafka;
+            _services.RegisterConnectionTo<QueueStub>((config) =>
+            {
+                config.QueueName = expectedQueueName;
+                config.QueueMechanism = QueueMechanism.RabbitMq;
+            });
+
+            _services.RegisterConnectionTo<QueueStub>((config) => config.QueueMechanism = ExpectedQueueMechanism);
+
+            using var provider = _services.BuildServiceProvider();
+            var prov = provider.GetRequiredService<ConfigConnectionProvider>();
+            prov.Should().NotBeNull();
+            prov.GetConfigTo<QueueStub>().QueueName.Should().Be(expectedQueueName);
+            prov.GetConfigTo<QueueStub>().QueueMechanism.Should().Be(ExpectedQueueMechanism);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenNoQueueSupportAddedd()
+        {
+            // Given
+            // _services.AddQueueSupport();
+
+            // When
+            Action act = () => _services.RegisterConnectionTo<QueueStub>((config) =>
+                     config.QueueMechanism = QueueMechanism.Kafka);
+
+            // Then
+            act.Should().ThrowExactly<InvalidOperationException>();
+        }
+    }
+}

--- a/__tests__/BlogDoFt.QueueComponentTest/Fixtures/FakerFixture.cs
+++ b/__tests__/BlogDoFt.QueueComponentTest/Fixtures/FakerFixture.cs
@@ -1,0 +1,11 @@
+﻿using Bogus;
+
+namespace BlogDoFt.QueueComponentTest.Fixtures
+{
+    public static class FakerFixture
+    {
+        private static Faker _faker;
+
+        public static Faker GetFaker() => _faker ??= new Faker("pt_BR");
+    }
+}

--- a/__tests__/BlogDoFt.QueueComponentTest/Fixtures/QueueStub.cs
+++ b/__tests__/BlogDoFt.QueueComponentTest/Fixtures/QueueStub.cs
@@ -1,0 +1,6 @@
+﻿namespace BlogDoFt.QueueComponentTest.Fixtures
+{
+    public class QueueStub
+    {
+    }
+}

--- a/src/BlogDoFt.QueueComponent/AssemblyInfo.cs
+++ b/src/BlogDoFt.QueueComponent/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BlogDoFt.QueueComponentTest")]

--- a/src/BlogDoFt.QueueComponent/BlogDoFt.QueueComponent.csproj
+++ b/src/BlogDoFt.QueueComponent/BlogDoFt.QueueComponent.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>BlogDoFt.QueueComponent</PackageId>
     <Version>1.0.0-alpha.1</Version>
     <Authors>Francisco Thiago de Almeida</Authors>
     <Company>BlogDoFt.com.br</Company>
-    <CodeAnalysisRuleSet>..\..\.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>../../.ruleset</CodeAnalysisRuleSet>
+    <ProjectGuid>E3DD1874-DEFA-4FDF-9442-464F117D35B9</ProjectGuid>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
@@ -23,13 +23,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
+    <AdditionalFiles Include="../../stylecop.json" />
+    <AdditionalFiles Include="AssemblyInfo.cs" />
   </ItemGroup>
-
   <ItemGroup>
-    <Folder Include="Configurations\" />
+    <None Update="appsettings.test.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
-
 </Project>

--- a/src/BlogDoFt.QueueComponent/Configurations/ConfigConnectionProvider.cs
+++ b/src/BlogDoFt.QueueComponent/Configurations/ConfigConnectionProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace BlogDoFt.QueueComponent.Configurations
+{
+    public sealed class ConfigConnectionProvider
+    {
+        private static ConfigConnectionProvider _singletonInstance;
+        private readonly Dictionary<string, QueueConnConfiguration> _configurations = new Dictionary<string, QueueConnConfiguration>(); 
+
+        private ConfigConnectionProvider()
+        {
+        }
+
+        internal static ConfigConnectionProvider NewInstance() => _singletonInstance ??= new ConfigConnectionProvider();
+
+        internal QueueConnConfiguration GetConfigTo<TClass>()
+        {
+            _configurations.TryGetValue(GetKey<TClass>(), out var configuration);
+            return configuration;
+        }
+
+        internal void SetConfigTo<TClass>(QueueConnConfiguration config)
+        {
+            var key = GetKey<TClass>();
+            _configurations.Remove(key);
+            _configurations.Add(key, config);
+        }
+
+        private string GetKey<TClass>() => typeof(TClass).FullName;
+    }
+}

--- a/src/BlogDoFt.QueueComponent/Configurations/QueueConnConfiguration.cs
+++ b/src/BlogDoFt.QueueComponent/Configurations/QueueConnConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using BlogDoFt.QueueComponent.Enums;
+using System.Collections.Generic;
+
+namespace BlogDoFt.QueueComponent.Configurations
+{
+    public class QueueConnConfiguration
+    {
+        public QueueConnConfiguration()
+        {
+            CustomParameters = new Dictionary<string, string>();
+            QueueMechanism = QueueMechanism.Unknown;
+        }
+
+        public string HostName { get; set; }
+
+        public int Port { get; set; }
+
+        public string User { get; set; }
+
+        public string Password { get; set; }
+
+        public int RetryCount { get; set; }
+
+        public int TimeoutMs { get; set; }
+
+        public string QueueName { get; set; }
+
+        public QueueMechanism QueueMechanism { get; set; }
+
+        public Dictionary<string, string> CustomParameters { get; set; }
+    }
+}

--- a/src/BlogDoFt.QueueComponent/Enums/QueueMechanism.cs
+++ b/src/BlogDoFt.QueueComponent/Enums/QueueMechanism.cs
@@ -1,0 +1,20 @@
+﻿namespace BlogDoFt.QueueComponent.Enums
+{
+    public enum QueueMechanism
+    {
+        /// <summary>
+        /// Unknown queue mechanism. May thrown exceptions.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Kafka.
+        /// </summary>
+        Kafka,
+
+        /// <summary>
+        /// RabbitMQ.
+        /// </summary>
+        RabbitMq,
+    }
+}

--- a/src/BlogDoFt.QueueComponent/Extensions/ConfigurationExtension.cs
+++ b/src/BlogDoFt.QueueComponent/Extensions/ConfigurationExtension.cs
@@ -1,0 +1,31 @@
+﻿using BlogDoFt.QueueComponent.Configurations;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace BlogDoFt.QueueComponent.Extensions
+{
+    public static class ConfigurationExtension
+    {
+        public static IServiceCollection AddQueueSupport(this IServiceCollection services) =>
+            services.AddSingleton(_ => ConfigConnectionProvider.NewInstance());
+
+        public static IServiceCollection RegisterConnectionTo<TClass>(
+            this IServiceCollection services,
+            Action<QueueConnConfiguration> configureQueue)
+        {
+            var provider = services.ConfigGetConfigConnectionProvider();
+            var config = provider.GetConfigTo<TClass>() ?? new QueueConnConfiguration();
+            configureQueue(config);
+            provider.SetConfigTo<TClass>(config);
+
+            return services;
+        }
+
+        private static ConfigConnectionProvider ConfigGetConfigConnectionProvider(
+            this IServiceCollection services)
+        {
+            using var provider = services.BuildServiceProvider();
+            return provider.GetRequiredService<ConfigConnectionProvider>();
+        }
+    }
+}

--- a/src/BlogDoFt.QueueComponent/appsettings.test.json
+++ b/src/BlogDoFt.QueueComponent/appsettings.test.json
@@ -1,0 +1,13 @@
+﻿{
+  "QueueConfig": {
+    "0": {
+      "HostName": "127.0.0.1",
+      "Port": 9090,
+      "User": "user",
+      "Password": "user-secret",
+      "RetryCount": 1,
+      "TimeoutMs": 1000,
+      "QueueMechanism": "RabbitMq"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Creates objects thats holds queues connections configurations. The multiple support is guaranteed by QueueMechanism, wich could be Kafka, RabbitMq or Unknown (default). 
User can vinculate a class/struct to a configuration as a IServiceCollection Extension. So, if client want to create a queue abstraction class, or yet, select a queue based on a message type, he can.

To know how to do, please, se unit test (on this PR)

